### PR TITLE
feat: implement module to deploy Coolify on Hetzner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 <h1 align="center">
-  terraform-module-template
+  terraform-hetzner-coolify
   <br>
 </h1>
 
-<h4 align="center">A terraform module repository template.</h4>
+<h4 align="center">A terraform module to deploy Coolify on Hetzner Cloud.</h4>
 
 <p align="center">
   <a href="#requirements">Requirements</a> •
@@ -12,7 +12,7 @@
   <a href="#modules">Modules</a> •
   <a href="#inputs">Inputs</a> •
   <a href="#Outputs">Outputs</a> •
-  <a href="#resources">Resources</a> •
+  <a href="#resources">Resources</a>
 </p>
 
 <!-- BEGIN_TF_DOCS -->
@@ -21,31 +21,79 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.8.4 |
+| <a name="requirement_hcloud"></a> [hcloud](#requirement\_hcloud) | 1.47.0 |
 
 ## Example
 
 ```hcl
 # Example, should give the user an idea about how to use this module.
 # This code is found in the examples directory.
+terraform {
+  required_version = ">= 1.8.4"
+  required_providers {
+    hcloud = {
+      source  = "hetznercloud/hcloud"
+      version = "1.47.0"
+    }
+  }
+}
+
+provider "hcloud" {}
+
+resource "hcloud_ssh_key" "root" {
+  name       = "root"
+  public_key = file("~/.ssh/id_ed25519.pub")
+}
+
+module "coolify" {
+  source = "../"
+
+  providers = {
+    hcloud = hcloud
+  }
+
+  server_type = "cax11"
+  location    = "nbg1"
+  ssh_keys    = [hcloud_ssh_key.root.id]
+}
+
+output "url" {
+  value = module.coolify.url
+}
 ```
 
 ## Providers
 
-No providers.
+| Name | Version |
+|------|---------|
+| <a name="provider_hcloud"></a> [hcloud](#provider\_hcloud) | 1.47.0 |
 
 ## Modules
 
-No modules.
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_cloudinit"></a> [cloudinit](#module\_cloudinit) | damoun/cloudinit/coolify | 1.0.0 |
 
 ## Inputs
 
-No inputs.
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_firewall_source_ips"></a> [firewall\_source\_ips](#input\_firewall\_source\_ips) | Source networks that have access to Coolify. | `list(string)` | <pre>[<br>  "0.0.0.0/0",<br>  "::/0"<br>]</pre> | no |
+| <a name="input_ipv4_enabled"></a> [ipv4\_enabled](#input\_ipv4\_enabled) | Whether the Coolify instance should have a public IPv4 address. | `bool` | `true` | no |
+| <a name="input_location"></a> [location](#input\_location) | The location where the Coolify instance should be created. | `string` | n/a | yes |
+| <a name="input_server_type"></a> [server\_type](#input\_server\_type) | The server type to use for the Coolify instance. | `string` | n/a | yes |
+| <a name="input_ssh_keys"></a> [ssh\_keys](#input\_ssh\_keys) | The SSH key IDs to use for the Coolify instance. | `list(string)` | n/a | yes |
 
 ## Outputs
 
-No outputs.
+| Name | Description |
+|------|-------------|
+| <a name="output_url"></a> [url](#output\_url) | The URL of the Coolify instance |
 
 ## Resources
 
-No resources.
+| Name | Type |
+|------|------|
+| [hcloud_firewall.coolify](https://registry.terraform.io/providers/hetznercloud/hcloud/1.47.0/docs/resources/firewall) | resource |
+| [hcloud_server.coolify](https://registry.terraform.io/providers/hetznercloud/hcloud/1.47.0/docs/resources/server) | resource |
 <!-- END_TF_DOCS -->

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -1,2 +1,34 @@
 # Example, should give the user an idea about how to use this module.
 # This code is found in the examples directory.
+terraform {
+  required_version = ">= 1.8.4"
+  required_providers {
+    hcloud = {
+      source  = "hetznercloud/hcloud"
+      version = "1.47.0"
+    }
+  }
+}
+
+provider "hcloud" {}
+
+resource "hcloud_ssh_key" "root" {
+  name       = "root"
+  public_key = file("~/.ssh/id_ed25519.pub")
+}
+
+module "coolify" {
+  source = "../"
+
+  providers = {
+    hcloud = hcloud
+  }
+
+  server_type = "cax11"
+  location    = "nbg1"
+  ssh_keys    = [hcloud_ssh_key.root.id]
+}
+
+output "url" {
+  value = module.coolify.url
+}

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,43 @@
+module "cloudinit" {
+  source  = "damoun/cloudinit/coolify"
+  version = "1.0.0"
+}
+
+resource "hcloud_firewall" "coolify" {
+  name = "coolify"
+
+  rule {
+    direction  = "in"
+    protocol   = "tcp"
+    port       = "8000"
+    source_ips = var.firewall_source_ips
+  }
+
+  rule {
+    direction  = "in"
+    protocol   = "tcp"
+    port       = "6001"
+    source_ips = var.firewall_source_ips
+  }
+
+  rule {
+    direction  = "in"
+    protocol   = "tcp"
+    port       = "22"
+    source_ips = var.firewall_source_ips
+  }
+}
+
+resource "hcloud_server" "coolify" {
+  name        = "coolify"
+  image       = "ubuntu-24.04"
+  server_type = var.server_type
+  location    = var.location
+  public_net {
+    ipv4_enabled = var.ipv4_enabled
+    ipv6_enabled = true
+  }
+  ssh_keys     = var.ssh_keys
+  firewall_ids = [hcloud_firewall.coolify.id]
+  user_data    = module.cloudinit.user_data
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,4 @@
+output "url" {
+  description = "The URL of the Coolify instance"
+  value       = "http://${hcloud_server.coolify.ipv4_address}:8000"
+}

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,3 +1,9 @@
 terraform {
   required_version = ">= 1.8.4"
+  required_providers {
+    hcloud = {
+      source  = "hetznercloud/hcloud"
+      version = "1.47.0"
+    }
+  }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,32 @@
+variable "location" {
+  description = "The location where the Coolify instance should be created."
+  type        = string
+
+  validation {
+    condition     = contains(["fsn1", "nbg1", "hel1", "ash", "hil"], var.location)
+    error_message = "Location must be \"fsn1\", \"nbg1\", \"hel1\", \"ash\" or \"hil\"."
+  }
+}
+
+variable "server_type" {
+  description = "The server type to use for the Coolify instance."
+  type        = string
+
+}
+
+variable "ssh_keys" {
+  description = "The SSH key IDs to use for the Coolify instance."
+  type        = list(string)
+}
+
+variable "ipv4_enabled" {
+  description = "Whether the Coolify instance should have a public IPv4 address."
+  type        = bool
+  default     = true
+}
+
+variable "firewall_source_ips" {
+  type        = list(string)
+  default     = ["0.0.0.0/0", "::/0"]
+  description = "Source networks that have access to Coolify."
+}


### PR DESCRIPTION
- Deploy Coolify on Hetzner with cloudinit
- Output the url of the Coolify instance
- Setup firewall rules