### PR TITLE
fix: allow http & https port on firewall

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ output "url" {
 
 | Name | Description |
 |------|-------------|
+| <a name="output_ipv4_address"></a> [ipv4\_address](#output\_ipv4\_address) | The IP of the Coolify instance |
+| <a name="output_ipv6_address"></a> [ipv6\_address](#output\_ipv6\_address) | The IPv6 of the Coolify instance |
 | <a name="output_url"></a> [url](#output\_url) | The URL of the Coolify instance |
 
 ## Resources

--- a/main.tf
+++ b/main.tf
@@ -16,6 +16,20 @@ resource "hcloud_firewall" "coolify" {
   rule {
     direction  = "in"
     protocol   = "tcp"
+    port       = "80"
+    source_ips = var.firewall_source_ips
+  }
+
+  rule {
+    direction  = "in"
+    protocol   = "tcp"
+    port       = "443"
+    source_ips = var.firewall_source_ips
+  }
+
+  rule {
+    direction  = "in"
+    protocol   = "tcp"
     port       = "6001"
     source_ips = var.firewall_source_ips
   }


### PR DESCRIPTION
Missing allow rules for port 80 & 443 so we can setup Let's Encrypt on Coolify.